### PR TITLE
Update package to allow default zoom and manual editting of lat/lon

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ dotnet add package XperienceCommunity.MapLocationSelector
    "xperiencecommunity.maplocation": {
        "MapLatitude": "<your default latitude, e.g. 53.799009663238486>",
        "MapLongitude": "<your default longitude, e.g. -1.549048364271424>"
+       "MapZoom": <your default zoom level, e.g. 10>
+       "ManualEntry": <true or false, whether to allow manual entry of lat/long>
    }
    ```
 

--- a/examples/DancingGoat/appsettings.json
+++ b/examples/DancingGoat/appsettings.json
@@ -21,7 +21,9 @@
   "CMSHashStringSalt": "eafa5ed8-d2c7-4f73-b965-add94410508d",
   "xperiencecommunity.maplocation": {
     "MapLatitude": "53.799009663238486",
-    "MapLongitude": "-1.549048364271424"
+    "MapLongitude": "-1.549048364271424",
+    "MapZoom": 8,
+    "ManualEntry": false
   },
   "CMSAdminClientModuleSettings": {
     "xperiencecommunity-map-location-selector": {

--- a/src/Admin/Client/package.json
+++ b/src/Admin/Client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xperiencecommunity-map-location-selector",
   "version": "1.0.0",
-  "description": "Xperience by Ketnico - Map Location Selector project.",
+  "description": "Xperience by Kentico - Map Location Selector project.",
   "private": true,
   "engines": {
     "node": ">=22"

--- a/src/Admin/Client/src/components/MapLocation/MapLocationFormComponent.tsx
+++ b/src/Admin/Client/src/components/MapLocation/MapLocationFormComponent.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { FormComponentProps } from "@kentico/xperience-admin-base";
 import {
-  Box,
+    Box,
+    FormEditMode,
   FormItemWrapper,
   Input,
   Spacing,
@@ -21,8 +22,10 @@ const customMarkerIcon = new Icon({
 export interface MapLocationFormComponentProps extends FormComponentProps {
   mapLatitude: number;
   mapLongitude: number;
+  mapZoom?: number;
   pinLatitude: number | null;
   pinLongitude: number | null;
+  manualEntry?: boolean;
 }
 
 export const MapLocationFormComponent: React.FC<
@@ -36,9 +39,12 @@ export const MapLocationFormComponent: React.FC<
     props.pinLongitude
   );
 
+  const decimalRegex = /^-?\d*\.?\d*$/
+
   const clickedPosition: LatLngTuple | null =
     latitude && longitude ? [latitude, longitude] : null;
 
+  let editableAttribute = !!!props.manualEntry || props.editMode != FormEditMode.Default ? { disabled: true } : {};
   // Marker click handler to clear the latitude and longitude values
   const handleMarkerClick = () => {
     setLatitude(null);
@@ -55,6 +61,43 @@ export const MapLocationFormComponent: React.FC<
     });
     return null;
   };
+
+    // Handle Manual Changes
+  const handleLatChange = (e: React.ChangeEvent<HTMLInputElement>) => 
+  {
+    let newValue = e.target.value;
+    if (props.onChange && decimalRegex.test(newValue))
+    {
+      if (!newValue)
+      {
+        newValue = "0";
+      }
+      var value = parseFloat(newValue);
+      if (Number.isNaN(value)) 
+      {
+        value = 0
+      }
+      setLatitude(value)
+    }
+  } 
+
+  const handleLonChange = (e: React.ChangeEvent<HTMLInputElement>) => 
+  {
+    let newValue = e.target.value;
+    if (props.onChange && decimalRegex.test(newValue))
+    {
+      if (!newValue)
+      {
+        newValue = "0";
+      }
+      var value = parseFloat(newValue);
+      if (Number.isNaN(value))
+      {
+        value = 0
+      }
+      setLongitude(value)
+    }
+  } 
 
   // Update the Kentico value when the latitude or longitude changes
   React.useEffect(
@@ -84,7 +127,7 @@ export const MapLocationFormComponent: React.FC<
       <Box spacingY={Spacing.S}>
         <MapContainer
           center={[props.mapLatitude, props.mapLongitude]}
-          zoom={15}
+          zoom={props.mapZoom ?? 15}
           style={{ height: "500px", width: "100%" }}
         >
           <TileLayer
@@ -108,8 +151,9 @@ export const MapLocationFormComponent: React.FC<
           label="Latitude"
           placeholder="Current latitude value"
           type="text"
-          disabled
-          value={latitude || ""}
+          {...editableAttribute}
+          value={latitude}
+          onChange={handleLatChange}
         />
       </Box>
       <Box spacingY={Spacing.S}>
@@ -117,8 +161,9 @@ export const MapLocationFormComponent: React.FC<
           label="Longitude"
           placeholder="Current longitude value"
           type="text"
-          disabled
-          value={longitude || ""}
+          {...editableAttribute}
+          value={longitude}
+          onChange={handleLonChange}
         />
       </Box>
     </FormItemWrapper>

--- a/src/Admin/Client/src/components/MapLocation/MapLocationFormComponent.tsx
+++ b/src/Admin/Client/src/components/MapLocation/MapLocationFormComponent.tsx
@@ -62,21 +62,27 @@ export const MapLocationFormComponent: React.FC<
     return null;
   };
 
-    // Handle Manual Changes
+  // Parse New Value
+  const parseNewValue = (newValue: string) =>
+  {
+    if (!newValue) {
+    newValue = "0";
+    }
+    var value = parseFloat(newValue);
+    if (Number.isNaN(value)) {
+      value = 0
+    }
+    return value
+  }
+
+
+  // Handle Manual Changes
   const handleLatChange = (e: React.ChangeEvent<HTMLInputElement>) => 
   {
     let newValue = e.target.value;
     if (props.onChange && decimalRegex.test(newValue))
     {
-      if (!newValue)
-      {
-        newValue = "0";
-      }
-      var value = parseFloat(newValue);
-      if (Number.isNaN(value)) 
-      {
-        value = 0
-      }
+      var value = parseNewValue(newValue);
       setLatitude(value)
     }
   } 
@@ -86,15 +92,7 @@ export const MapLocationFormComponent: React.FC<
     let newValue = e.target.value;
     if (props.onChange && decimalRegex.test(newValue))
     {
-      if (!newValue)
-      {
-        newValue = "0";
-      }
-      var value = parseFloat(newValue);
-      if (Number.isNaN(value))
-      {
-        value = 0
-      }
+      var value = parseNewValue(newValue);
       setLongitude(value)
     }
   } 

--- a/src/Admin/Client/src/components/MapLocation/MapLocationFormComponent.tsx
+++ b/src/Admin/Client/src/components/MapLocation/MapLocationFormComponent.tsx
@@ -69,9 +69,9 @@ export const MapLocationFormComponent: React.FC<
     if (!newValue) {
       newValue = DEFAULT_VALUE;
     }
-    var value = parseFloat(newValue);
+    let value = parseFloat(newValue);
     if (Number.isNaN(value)) {
-      value = 0
+      value = 0;
     }
     return value
   }
@@ -83,7 +83,7 @@ export const MapLocationFormComponent: React.FC<
     let newValue = e.target.value;
     if (props.onChange && decimalRegex.test(newValue))
     {
-      var value = parseNewValue(newValue);
+      const value = parseNewValue(newValue);
       setLatitude(value)
     }
   } 

--- a/src/Admin/Client/src/components/MapLocation/MapLocationFormComponent.tsx
+++ b/src/Admin/Client/src/components/MapLocation/MapLocationFormComponent.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { FormComponentProps } from "@kentico/xperience-admin-base";
 import {
-    Box,
-    FormEditMode,
+  Box,
+  FormEditMode,
   FormItemWrapper,
   Input,
   Spacing,
@@ -39,12 +39,13 @@ export const MapLocationFormComponent: React.FC<
     props.pinLongitude
   );
 
-  const decimalRegex = /^-?\d*\.?\d*$/
+  const decimalRegex = /^-?\d*\.?\d*$/;
+  const DEFAULT_VALUE = "0";
 
   const clickedPosition: LatLngTuple | null =
     latitude && longitude ? [latitude, longitude] : null;
 
-  let editableAttribute = !!!props.manualEntry || props.editMode != FormEditMode.Default ? { disabled: true } : {};
+  let editableAttribute = !props.manualEntry || props.editMode != FormEditMode.Default ? { disabled: true } : {};
   // Marker click handler to clear the latitude and longitude values
   const handleMarkerClick = () => {
     setLatitude(null);
@@ -66,7 +67,7 @@ export const MapLocationFormComponent: React.FC<
   const parseNewValue = (newValue: string) =>
   {
     if (!newValue) {
-    newValue = "0";
+      newValue = DEFAULT_VALUE;
     }
     var value = parseFloat(newValue);
     if (Number.isNaN(value)) {

--- a/src/Admin/UIFormComponents/MapLocation/MapLocationFormComponent.cs
+++ b/src/Admin/UIFormComponents/MapLocation/MapLocationFormComponent.cs
@@ -28,6 +28,10 @@ namespace XperienceCommunity.MapLocationSelector
             clientProperties.MapLatitude = ValidationHelper.GetDouble(_mapLocationOptions.MapLatitude, 0);
             clientProperties.MapLongitude = ValidationHelper.GetDouble(_mapLocationOptions.MapLongitude, 0);
 
+            clientProperties.MapZoom = ValidationHelper.GetInteger(_mapLocationOptions.MapZoom, 15);
+
+            clientProperties.ManualEntry = ValidationHelper.GetBoolean(_mapLocationOptions.ManualEntry, false);
+
             // Check for an existing stored value, if we have one then prepare the data for the react component
             if (!string.IsNullOrWhiteSpace(clientProperties.Value))
             {
@@ -59,9 +63,13 @@ namespace XperienceCommunity.MapLocationSelector
 
         public double MapLongitude { get; set; }
 
+        public int MapZoom { get; set; }
+
         public double? PinLatitude { get; set; }
 
         public double? PinLongitude { get; set; }
+
+        public bool? ManualEntry { get; set; }
     }
 
     // Attribute for usage for widget field configurations

--- a/src/Models/MapLocationOptions.cs
+++ b/src/Models/MapLocationOptions.cs
@@ -27,7 +27,7 @@
         }
 
         /// <summary>
-        /// The map starting longitude.
+        /// Change the default zoom level of the map.
         /// </summary>
         public int? MapZoom
         {
@@ -36,7 +36,7 @@
         }
 
         /// <summary>
-        /// The map starting longitude.
+        /// Allow the manual entry of latitude and longitude coordinates.
         /// </summary>
         public bool? ManualEntry
         {

--- a/src/Models/MapLocationOptions.cs
+++ b/src/Models/MapLocationOptions.cs
@@ -25,5 +25,23 @@
             get;
             set;
         }
+
+        /// <summary>
+        /// The map starting longitude.
+        /// </summary>
+        public int? MapZoom
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// The map starting longitude.
+        /// </summary>
+        public bool? ManualEntry
+        {
+            get;
+            set;
+        }
     }
 }

--- a/src/XperienceCommunity.MapLocationSelector.csproj
+++ b/src/XperienceCommunity.MapLocationSelector.csproj
@@ -7,7 +7,7 @@
 	<PropertyGroup>
 		<Title>Xperience by Kentico Map Location Selector</Title>
 		<PackageId>XperienceCommunity.MapLocationSelector</PackageId>
-		<Version>2.0.3</Version>
+		<Version>2.1.0</Version>
 		<Authors>Liam Goldfinch</Authors>
 		<Company>Liam Goldfinch</Company>
 		<PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
- Fixed a typo in the package Description
- Add a MapZoom variable that controls the default zoom level of the map
- Update the input fields to be editable if configured.
- - Validates the input is a decimal
- - Prevents NaN softlock if the editor deletes the entire input
- - Ensure that the Text Inputs are disabled when the page cannot be edited